### PR TITLE
Fix autoloaded expression's use of undefined function

### DIFF
--- a/prisma-ts-mode.el
+++ b/prisma-ts-mode.el
@@ -268,8 +268,7 @@
     (treesit-major-mode-setup)))
 
 ;;;###autoload
-(if (treesit-ready-p 'prisma)
-    (add-to-list 'auto-mode-alist '("\\.prisma\\'" . prisma-ts-mode)))
+(add-to-list 'auto-mode-alist '("\\.prisma\\'" . prisma-ts-mode))
 
 (provide 'prisma-ts-mode)
 ;; Local Variables:


### PR DESCRIPTION
Hi there - thanks for creating prisma-ts-mode.

Recently I noticed the following error nestled in the middle of my `*Messages*` buffer:

`Error loading autoloads: (void-function treesit-ready-p)`

After investigating, I found that it was because this package uses the `treesit-ready-p` function in an autoloaded expression, but at the time the generated `prisma-ts-mode-autoloads.el` file is executed during Emacs startup ("package activation time"), the `treesit` library is not necessarily loaded and so that function isn't defined. I think the only reason this error isn't "in one's face" by halting Emacs startup completely is because errors are "demoted" [here](https://github.com/emacs-mirror/emacs/blob/47454566772479c706ea53b4ee9ad5caaafd9130/lisp/emacs-lisp/package.el#L909-L910).

It seems that Tree-sitter based modes that tweak `auto-mode-alist` in an `;;;###autoload`'d expression [typically do so unconditionally](https://github.com/search?q=path%3A*-ts-mode.el+%2F%3B%3B%3B%23%23%23autoload%5Cn%5C%28add-to-list+%27auto-mode-alist+%2F&type=code) so I've just removed the conditional.